### PR TITLE
TYNSTEP-1370 Allow superscript notes to be clicked and kept open 

### DIFF
--- a/step-web/src/main/webapp/css/passage.css
+++ b/step-web/src/main/webapp/css/passage.css
@@ -265,6 +265,12 @@ SUP.note a {
 	color: #26539e;
 }
 
+sup.note a:hover,
+sup.note a:focus,
+sup.note a:visited {
+	text-decoration: none;
+}
+
 SUP.note a:visited {
 	font-size: 100%;
     font-weight:normal;

--- a/step-web/src/main/webapp/js/backbone/views/view_display_passage.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_display_passage.js
@@ -252,9 +252,17 @@ var PassageDisplayView = DisplayView.extend({
                 link.on("touchstart", function () {
                     self.doInlineNoteQuickLexicon(passageContent, $(this), ev);
                 }).hover(function (ev) {
-                    self.doInlineNoteQuickLexicon(passageContent, $(this), ev)
+                    // If another note is already open, don't replace the content on hover
+                    if (!step.util.keepQuickLexiconOpen) {
+                        self.doInlineNoteQuickLexicon(passageContent, $(this), ev);
+                    }
                 }, function () {
-                    $("#quickLexicon").remove();
+                    // Avoid automatically hiding quickLexicon if the user has clicked
+                    if (!step.util.keepQuickLexiconOpen) {
+                        $("#quickLexicon").remove();
+                    }
+                }).click(function (ev) {
+                    step.util.keepQuickLexiconOpen = true;
                 });
             }
         },

--- a/step-web/src/main/webapp/js/backbone/views/view_quick_lexicon.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_quick_lexicon.js
@@ -112,6 +112,7 @@ var QuickLexicon = Backbone.View.extend({
 
         lexicon.find(".close").click(function () {
             lexicon.remove();
+            step.util.keepQuickLexiconOpen = false;
         });
 
         this.passageContainer.find(".passageContent > .passageContentHolder, .passageContent > span").one('scroll', function() {

--- a/step-web/src/main/webapp/js/step.util.js
+++ b/step-web/src/main/webapp/js/step.util.js
@@ -987,14 +987,17 @@ step.util = {
                 var hoverContext = this;
                 require(['quick_lexicon'], function () {
                     step.util.delay(function () {
-                        //do the quick lexicon
+                        // do the quick lexicon
                         step.util.ui._displayNewQuickLexicon(hoverContext, ev, passageId, false);
+                        step.util.keepQuickLexiconOpen = false;
                     }, MOUSE_PAUSE, 'show-quick-lexicon');
                 });
             }, function () {
                 step.passage.removeStrongsHighlights(undefined, "primaryLightBg relatedWordEmphasisHover");
                 step.util.delay(undefined, 0, 'show-quick-lexicon');
-                $("#quickLexicon").remove();
+                if (!step.util.keepQuickLexiconOpen) {
+                    $("#quickLexicon").remove();
+                }
             });
         },
         _displayNewQuickLexicon: function (hoverContext, ev, passageId, touchEvent) {

--- a/step-web/src/main/webapp/scss/quick_lexicon.scss
+++ b/step-web/src/main/webapp/scss/quick_lexicon.scss
@@ -75,6 +75,8 @@
   }
 
   .close {
-    padding-left:10px;
+    color: white;
+    opacity: .8;
+    padding-left: 10px;
   }
 }


### PR DESCRIPTION
...until another quickLexicon is triggered or the close icon is clicked)

- Removed underline on hover/focus for superscript notes (especially off-looking for triangle icon)
- Updated styles for close icon in quickLexicon (easier to see)